### PR TITLE
[TASK-12569] Add quick voice cloning MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,28 @@ This project implements a Model [Context Protocol server](https://modelcontextpr
 | Preset Mode                      | ✅     |
 | Smart Mode                       | ✅     |
 | **Quick Voice Cloning**          |        |
-| Clone / Delete Voice             | ⏳ pending typecast-sdk PR #32, #33 prod release |
+| Clone Voice                      | ✅     |
+| Delete Cloned Voice              | ✅     |
+
+## Quick Voice Cloning
+
+The MCP server exposes two tools for temporary custom voice workflows:
+
+- `clone_voice`: creates a quick-cloned custom voice from a local WAV or MP3 file.
+- `delete_cloned_voice`: deletes a cloned voice ID that starts with `uc_`.
+
+Quick cloning constraints:
+
+- Voice name must be 1-30 characters.
+- Audio sample must be WAV or MP3.
+- Audio sample must be 25 MB or smaller.
+- Use `ssfm-v30` unless you have a specific compatibility reason.
+
+Typical flow:
+
+1. Run `clone_voice` with `name`, `audio_file_path`, and optional `model`.
+2. Use the returned `next_step_voice_id` and `next_step_model` in `text_to_speech`, `text_to_speech_stream`, or `text_to_speech_with_timestamps`.
+3. Run `delete_cloned_voice` when the temporary cloned voice is no longer needed.
 
 ## Setup
 

--- a/app/knowledge.py
+++ b/app/knowledge.py
@@ -223,6 +223,32 @@ GET /v1/voices?model=ssfm-v21
 GET /v1/voices/{voice_id}
 ```
 
+#### 5. Quick Voice Cloning
+```
+POST /v1/voices/clone
+DELETE /v1/voices/{voice_id}
+```
+
+Quick Voice Cloning creates a custom cloned voice from a short WAV or MP3 audio
+sample. Use it when a user needs a temporary custom voice and then wants to
+generate speech with that cloned voice.
+
+**Clone Voice Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | Display name for the cloned voice. Must be 1-30 characters. |
+| `model` | string | Voice cloning model. Use `ssfm-v30` by default. |
+| `file` | binary | WAV or MP3 audio sample. Maximum size is 25 MB. |
+
+**Delete Cloned Voice:**
+- Only cloned custom voice IDs that start with `uc_` should be deleted.
+- Built-in Typecast voices usually start with `tc_` and should not be passed to delete.
+
+**Recommended workflow:**
+1. Clone a voice with `POST /v1/voices/clone`.
+2. Use the returned `voice_id` with `POST /v1/text-to-speech`.
+3. Delete the cloned voice with `DELETE /v1/voices/{voice_id}` when no longer needed.
+
 ### API Characteristics
 - **Synchronous**: The API returns audio data directly in the response
 - **No SSML Support**: Currently SSML is not supported (use speed/volume parameters instead)
@@ -321,6 +347,45 @@ if response.status_code == 200:
     print("Audio saved successfully!")
 else:
     print(f"Error: {response.status_code} - {response.text}")
+```
+
+### Python (Direct API) - Quick Voice Cloning
+
+```python
+import requests
+
+api_key = "YOUR_API_KEY"
+
+with open("sample.wav", "rb") as audio_file:
+    clone_response = requests.post(
+        "https://api.typecast.ai/v1/voices/clone",
+        headers={"X-API-KEY": api_key},
+        data={"name": "My Cloned Voice", "model": "ssfm-v30"},
+        files={"file": ("sample.wav", audio_file, "audio/wav")},
+    )
+clone_response.raise_for_status()
+
+cloned_voice = clone_response.json()
+voice_id = cloned_voice.get("voice_id") or cloned_voice["result"]["voice_id"]
+
+speech_response = requests.post(
+    "https://api.typecast.ai/v1/text-to-speech",
+    headers={"X-API-KEY": api_key, "Content-Type": "application/json"},
+    json={
+        "text": "Hello from my cloned voice.",
+        "model": "ssfm-v30",
+        "voice_id": voice_id,
+    },
+)
+speech_response.raise_for_status()
+
+with open("cloned_voice_output.wav", "wb") as f:
+    f.write(speech_response.content)
+
+requests.delete(
+    f"https://api.typecast.ai/v1/voices/{voice_id}",
+    headers={"X-API-KEY": api_key},
+).raise_for_status()
 ```
 
 ### JavaScript/TypeScript (Using SDK) - Recommended
@@ -634,4 +699,3 @@ Typecast SSFM is also available on AWS Marketplace. Suitable for enterprises tha
 - [API Reference](https://typecast.ai/docs/api-reference)
 - [AWS Marketplace](https://aws.amazon.com/marketplace/seller-profile?id=seller-rauqp3qawr25s)
 """
-

--- a/app/knowledge.py
+++ b/app/knowledge.py
@@ -366,7 +366,10 @@ with open("sample.wav", "rb") as audio_file:
 clone_response.raise_for_status()
 
 cloned_voice = clone_response.json()
-voice_id = cloned_voice.get("voice_id") or cloned_voice["result"]["voice_id"]
+clone_result = cloned_voice.get("result") or cloned_voice.get("data") or cloned_voice
+voice_id = clone_result.get("voice_id") or clone_result.get("voiceId")
+if not voice_id:
+    raise ValueError(f"voice_id not found in clone response: {cloned_voice}")
 
 speech_response = requests.post(
     "https://api.typecast.ai/v1/text-to-speech",
@@ -381,6 +384,9 @@ speech_response.raise_for_status()
 
 with open("cloned_voice_output.wav", "wb") as f:
     f.write(speech_response.content)
+
+if not voice_id.startswith("uc_"):
+    raise ValueError(f"Refusing to delete non-cloned voice ID: {voice_id}")
 
 requests.delete(
     f"https://api.typecast.ai/v1/voices/{voice_id}",

--- a/app/server.py
+++ b/app/server.py
@@ -285,6 +285,11 @@ async def clone_voice(
         result = {"raw": payload}
 
     voice_id = result.get("voice_id") or result.get("voiceId")
+    if not voice_id:
+        raise ValueError(f"Failed to extract voice_id from clone response: {payload}")
+    if not voice_id.startswith("uc_"):
+        raise ValueError("Only cloned voice IDs that start with 'uc_' can be deleted.")
+
     voice_name = result.get("name") or result.get("voice_name") or name
 
     return {

--- a/app/server.py
+++ b/app/server.py
@@ -1,4 +1,5 @@
 import base64
+import mimetypes
 import os
 import re
 from datetime import datetime
@@ -18,6 +19,7 @@ API_HOST = os.environ.get("TYPECAST_API_HOST", "https://api.typecast.ai")
 API_KEY = os.environ.get("TYPECAST_API_KEY")
 OUTPUT_DIR = Path(os.environ.get("TYPECAST_OUTPUT_DIR", os.path.expanduser("~/Downloads/typecast_output")))
 HTTP_HEADERS = { "X-API-KEY": API_KEY }
+QUICK_CLONING_MAX_FILE_SIZE = 25 * 1024 * 1024
 
 
 def _sanitize_for_filename(s: str) -> str:
@@ -29,6 +31,32 @@ def _sanitize_for_filename(s: str) -> str:
     output directory.
     """
     return re.sub(r'[<>:"/\\|?*\x00-\x1f]', "_", s)
+
+
+def _validate_quick_clone_audio_path(audio_file_path: str) -> tuple[Path, str, int]:
+    audio_path = Path(audio_file_path).expanduser()
+    if not audio_path.exists() or not audio_path.is_file():
+        raise ValueError(f"Audio file does not exist: {audio_file_path}")
+
+    file_size = audio_path.stat().st_size
+    if file_size > QUICK_CLONING_MAX_FILE_SIZE:
+        raise ValueError(
+            f"Audio file exceeds the 25 MB quick cloning limit; got {file_size} bytes."
+        )
+
+    content_type = mimetypes.guess_type(audio_path.name)[0]
+    if content_type == "audio/x-wav":
+        content_type = "audio/wav"
+    if content_type not in {"audio/wav", "audio/mpeg"}:
+        suffix = audio_path.suffix.lower()
+        if suffix == ".wav":
+            content_type = "audio/wav"
+        elif suffix == ".mp3":
+            content_type = "audio/mpeg"
+        else:
+            raise ValueError("Quick cloning accepts WAV or MP3 audio only.")
+
+    return audio_path, content_type, file_size
 
 app = FastMCP(
     "typecast-api-mcp-server",
@@ -200,6 +228,100 @@ async def get_voice(voice_id: str) -> dict:
         if response.status_code != 200:
             raise Exception(f"Failed to get voice: {response.status_code}")
         return response.json()
+
+
+@app.tool("clone_voice", "Create a quick-cloned custom voice from a local WAV or MP3 audio sample")
+async def clone_voice(
+    name: str,
+    audio_file_path: str,
+    model: str = TTSModel.SSFM_V30.value,
+) -> dict:
+    """Create a quick-cloned custom voice.
+
+    Calls POST /v1/voices/clone with multipart form data. Use the returned
+    voice_id with text_to_speech, text_to_speech_stream, or
+    text_to_speech_with_timestamps. Delete temporary cloned voices with
+    delete_cloned_voice when they are no longer needed.
+
+    Args:
+        name: Display name for the cloned voice. Must be 1-30 characters.
+        audio_file_path: Local WAV or MP3 sample path. Maximum file size is 25 MB.
+        model: Voice cloning model. Default: ssfm-v30.
+
+    Returns:
+        Dict returned by the Typecast API plus normalized handoff fields:
+            voice_id, cloned_voice_id, next_step_voice_id, next_step_model.
+    """
+    char_count = len(name)
+    if char_count < 1 or char_count > 30:
+        raise ValueError(f"Voice name must be 1-30 characters; got {char_count}.")
+
+    model_enum = TTSModel(model)
+    audio_path, content_type, file_size = _validate_quick_clone_audio_path(audio_file_path)
+
+    async with httpx.AsyncClient(
+        timeout=httpx.Timeout(connect=10.0, write=120.0, read=120.0, pool=10.0)
+    ) as client:
+        with audio_path.open("rb") as audio_file:
+            response = await client.post(
+                f"{API_HOST}/v1/voices/clone",
+                headers=HTTP_HEADERS,
+                data={"name": name, "model": model_enum.value},
+                files={
+                    "file": (
+                        audio_path.name,
+                        audio_file,
+                        content_type,
+                    )
+                },
+            )
+
+    if response.status_code not in {200, 201}:
+        raise Exception(f"Failed to clone voice: {response.status_code}, {response.text}")
+
+    payload = response.json()
+    result = payload.get("result") or payload.get("data") or payload
+    if not isinstance(result, dict):
+        result = {"raw": payload}
+
+    voice_id = result.get("voice_id") or result.get("voiceId")
+    voice_name = result.get("name") or result.get("voice_name") or name
+
+    return {
+        **result,
+        "voice_id": voice_id,
+        "cloned_voice_id": voice_id,
+        "voice_name": voice_name,
+        "name": voice_name,
+        "model": result.get("model") or model_enum.value,
+        "file_size": file_size,
+        "next_step_voice_id": voice_id,
+        "next_step_model": result.get("model") or model_enum.value,
+    }
+
+
+@app.tool("delete_cloned_voice", "Delete a quick-cloned custom voice by voice ID")
+async def delete_cloned_voice(voice_id: str) -> dict:
+    """Delete a quick-cloned custom voice.
+
+    Args:
+        voice_id: Cloned voice ID returned by clone_voice. Must start with uc_.
+
+    Returns:
+        Dict with success=true and the deleted voice_id.
+    """
+    if not voice_id.startswith("uc_"):
+        raise ValueError("Only cloned voice IDs that start with 'uc_' can be deleted.")
+
+    async with httpx.AsyncClient(
+        timeout=httpx.Timeout(connect=10.0, write=10.0, read=30.0, pool=10.0)
+    ) as client:
+        response = await client.delete(f"{API_HOST}/v1/voices/{voice_id}", headers=HTTP_HEADERS)
+
+    if response.status_code not in {200, 204}:
+        raise Exception(f"Failed to delete cloned voice: {response.status_code}, {response.text}")
+
+    return {"id": voice_id, "voice_id": voice_id, "success": True}
 
 
 @app.tool("text_to_speech", "Convert text to speech using the specified voice and parameters")


### PR DESCRIPTION
## Summary
- add MCP tools for quick voice cloning and cloned voice deletion
- document the clone/use/delete workflow in README and agent knowledge
- validate local WAV/MP3 samples, 1-30 character names, and the 25 MB file limit

## Verification
- uv run python -m compileall app
- uv run python quick clone validation script for WAV, invalid extension, and >25 MB cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 빠른 음성 클로닝 기능 추가
  * 사용자 음성 클로닝 및 삭제 도구 구현
  * WAV/MP3 형식 오디오 파일 지원(최대 25MB)
  * 클로닝된 음성으로 텍스트-음성 변환 지원
  * 완전한 설정 가이드 및 사용 예제 문서화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->