### PR TITLE
Add target_lufs support to streaming TTS tool

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -366,6 +366,9 @@ async def text_to_speech(
     Returns:
         Path to the saved audio file
     """
+    if target_lufs is not None and not (-70.0 <= target_lufs <= 0.0):
+        raise ValueError(f"target_lufs must be between -70.0 and 0.0, got {target_lufs}")
+
     if not OUTPUT_DIR.exists():
         OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 

--- a/app/server.py
+++ b/app/server.py
@@ -124,7 +124,7 @@ class Output(BaseModel):
     audio_format: str = Field(default="wav", pattern="^(wav|mp3)$", description="Audio file format")
     target_lufs: float | None = Field(
         default=None,
-        description="Absolute loudness normalization target in LUFS. Mutually exclusive with volume on the non-streaming endpoint (any presence of volume causes 4xx); not accepted by the streaming endpoint at all.",
+        description="Absolute loudness normalization target in LUFS. Mutually exclusive with volume on the non-streaming endpoint (any presence of volume causes 4xx). Supported by streaming TTS.",
         ge=-70.0,
         le=0.0,
     )
@@ -463,14 +463,15 @@ async def text_to_speech_stream(
     audio_pitch: int = 0,
     audio_tempo: float = 1.0,
     audio_format: str = "wav",
+    target_lufs: float | None = None,
 ) -> str:
     """Convert text to speech via the streaming endpoint and save the result.
 
     Calls POST /v1/text-to-speech/stream which returns chunked audio data
     in real time. The chunks are concatenated and saved as a single file.
 
-    Note: the streaming endpoint does not accept volume or target_lufs (the
-    server rejects those fields). Use text_to_speech for full output controls.
+    Note: the streaming endpoint does not accept volume, but supports
+    target_lufs for absolute loudness normalization.
 
     Args:
         voice_id: ID of the voice to use
@@ -484,6 +485,7 @@ async def text_to_speech_stream(
         audio_pitch: -12 ~ 12 (default: 0)
         audio_tempo: 0.5 ~ 2.0 (default: 1.0)
         audio_format: 'wav' or 'mp3' (default: wav)
+        target_lufs: Optional absolute loudness normalization target in LUFS (-70.0 ~ 0.0)
 
     Returns:
         Path to the saved audio file
@@ -516,6 +518,8 @@ async def text_to_speech_stream(
         "audio_tempo": audio_tempo,
         "audio_format": audio_format,
     }
+    if target_lufs is not None:
+        output_payload["target_lufs"] = target_lufs
 
     request_payload = {
         "voice_id": voice_id,


### PR DESCRIPTION
## Summary
- Add `target_lufs` input to the streaming TTS MCP tool
- Forward `target_lufs` into the streaming `output` payload when provided
- Update the Output schema description to state that streaming TTS supports `target_lufs`

## Validation
- `python3 -m compileall app` passed
- `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 변경사항

* **새로운 기능**
  * 스트리밍 방식 TTS 엔드포인트에서 목표 음량(LUFS) 설정(`target_lufs`)을 지원합니다. 요청 시 `target_lufs` 값을 제공한 경우에만 적용됩니다.
* **개선/검증**
  * 비스트리밍 TTS에서 `target_lufs`가 제공되면 `-70.0 ~ 0.0` 범위 검증을 추가했으며, 범위를 벗어나면 요청이 중단됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->