### PR TITLE
Add recommend voices MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This project implements a Model [Context Protocol server](https://modelcontextpr
 | Get Voices (V2 API)              | ✅     |
 | Get Voices `use_cases` filter    | ✅     |
 | Get Voice (V2 API)               | ✅     |
+| Recommend Voices                 | ✅     |
 | Text to Speech                   | ✅     |
 | Text to Speech (Streaming)       | ✅     |
 | Text to Speech (with Timestamps) | ✅     |
@@ -59,6 +60,17 @@ Typical flow:
 1. Run `clone_voice` with `name`, `audio_file_path`, and optional `model`.
 2. Use the returned `next_step_voice_id` and `next_step_model` in `text_to_speech`, `text_to_speech_stream`, or `text_to_speech_with_timestamps`.
 3. Run `delete_cloned_voice` when the temporary cloned voice is no longer needed.
+
+## Voice Recommendations
+
+Use `recommend_voices` when you know the desired style, mood, language, or use
+case but do not know the exact voice ID yet. It calls
+`GET /v1/voices/recommendations` and returns candidates sorted by score.
+
+The recommendation response intentionally contains only `voice_id`,
+`voice_name`, and `score`. If an agent needs details about a recommended voice,
+call `get_voice` for each returned ID or `get_voices` for a broader filtered
+list before using the ID in TTS.
 
 ## Setup
 

--- a/app/knowledge.py
+++ b/app/knowledge.py
@@ -212,18 +212,29 @@ GET /v2/voices?model=ssfm-v30&gender=female&age=young_adult
 | `age` | string | Filter by age: "child", "teen", "young_adult", "middle_aged", "senior" |
 | `use_cases` | string | Filter by use case |
 
-#### 3. List Voices (V1 API - Legacy)
+#### 3. Recommend Voices
+```
+GET /v1/voices/recommendations?query=warm%20female%20voice%20for%20product%20tutorial&count=5
+```
+
+Use this endpoint when a user describes the desired voice style but does not
+know the exact voice ID. It returns recommended `voice_id`, `voice_name`, and
+`score` values only. For details such as supported models, emotions, gender,
+age, and use cases, call `GET /v2/voices` or `GET /v2/voices/{voice_id}` with
+the returned IDs.
+
+#### 4. List Voices (V1 API - Legacy)
 ```
 GET /v1/voices
 GET /v1/voices?model=ssfm-v21
 ```
 
-#### 4. Get Specific Voice
+#### 5. Get Specific Voice
 ```
 GET /v1/voices/{voice_id}
 ```
 
-#### 5. Quick Voice Cloning
+#### 6. Quick Voice Cloning
 ```
 POST /v1/voices/clone
 DELETE /v1/voices/{voice_id}

--- a/app/server.py
+++ b/app/server.py
@@ -161,6 +161,13 @@ class VoiceV2(BaseModel):
     use_cases: list[str] | None = Field(default=None, description="Recommended use cases")
 
 
+class RecommendedVoice(BaseModel):
+    """Recommended voice candidate returned by the recommendation API."""
+    voice_id: str = Field(description="Recommended Typecast voice identifier")
+    voice_name: str = Field(description="Display name returned with the recommendation")
+    score: float = Field(description="Recommendation relevance score")
+
+
 class TTSRequest(BaseModel):
     voice_id: str = Field(description="Voice identifier to use")
     text: str = Field(description="Text to convert to speech")
@@ -209,6 +216,37 @@ async def get_voices(
         if response.status_code != 200:
             raise Exception(f"Failed to get voices: {response.status_code}")
         return response.json()
+
+
+@app.tool("recommend_voices", "Recommend Typecast voices from a text description")
+async def recommend_voices(query: str, count: int = 5) -> list[dict]:
+    """Recommend voices that match a natural-language text description.
+
+    The recommendation API returns only voice_id, voice_name, and score. Call
+    get_voices or get_voice with the returned IDs when you need metadata such as
+    supported models, emotions, gender, age, or use cases before making a TTS
+    request.
+
+    Args:
+        query: Text description of the desired style, mood, language, use case,
+            or content context.
+        count: Maximum number of recommendations to return. Must be 1-10.
+
+    Returns:
+        Recommended voice candidates sorted by relevance score.
+    """
+    if not query.strip():
+        raise ValueError("query is required")
+    if count < 1 or count > 10:
+        raise ValueError("count must be between 1 and 10")
+
+    url = f"{API_HOST}/v1/voices/recommendations?{urlencode({'query': query, 'count': count})}"
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get(url, headers=HTTP_HEADERS)
+        if response.status_code != 200:
+            raise Exception(f"Failed to recommend voices: {response.status_code}")
+        return [RecommendedVoice(**voice).model_dump() for voice in response.json()]
 
 
 @app.tool("get_voice", "Get detailed information for a specific voice by ID using V2 API")


### PR DESCRIPTION
## Summary
- Add `recommend_voices` MCP tool for `GET /v1/voices/recommendations`
- Document that recommendation results include only `voice_id`, `voice_name`, and `score`
- Update MCP knowledge content with follow-up metadata lookup guidance

## Verification
- `uv run python -m compileall app`