### PR TITLE
chore: update CodeQL action pins

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,10 +24,10 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9
         with:
           languages: python
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9


### PR DESCRIPTION
## Summary
- update both CodeQL init and analyze actions to the same 4.37.0 pinned SHA
- supersedes the separate Dependabot PRs that updated only one CodeQL step at a time

## Verification
- git diff --check
- verified both CodeQL action pins are identical

The existing Dependabot PRs failed because init/analyze used mixed CodeQL action versions, producing: 'Loaded a configuration file for version 4.36.3, but running version 4.37.0'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선**
  - 코드 보안 분석 워크플로를 최신 상태로 업데이트했습니다.
  - 기존 분석 설정과 실행 방식은 그대로 유지되어, 보안 검사 결과와 사용 경험에 미치는 영향은 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->